### PR TITLE
[FEAT] 소모임 생성 기능 구현 및 화면 연결 (GroupFormScreen, HomeScreen)

### DIFF
--- a/src/main/java/gotcha/common/Session.java
+++ b/src/main/java/gotcha/common/Session.java
@@ -1,0 +1,6 @@
+package gotcha.common;
+
+public class Session {
+	//로그인 시 user_id, host_id 처리 위한 세션 관리
+    public static int loggedInUserId = -1;
+}

--- a/src/main/java/gotcha/dao/GroupDAO.java
+++ b/src/main/java/gotcha/dao/GroupDAO.java
@@ -1,0 +1,46 @@
+package gotcha.dao;
+
+import gotcha.common.DBConnector;
+
+import java.sql.*;
+
+public class GroupDAO {
+
+    public boolean insertGroup(
+            int hostId,
+            String title,
+            String context,
+            int maxParticipants,
+            String mainRegion,
+            String category,
+            Timestamp recruitDeadline,
+            String status
+    ) {
+        String sql = "INSERT INTO class " +
+                "(host_id, title, context, max_participants, main_region, category, recruit_deadline, status) " +
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
+
+        try (Connection conn = DBConnector.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+
+            stmt.setInt(1, hostId);
+            stmt.setString(2, title);
+            stmt.setString(3, context);
+            stmt.setInt(4, maxParticipants);
+            stmt.setString(5, mainRegion);
+            stmt.setString(6, category);
+
+            if (recruitDeadline != null) {
+                stmt.setTimestamp(7, recruitDeadline);
+            } else {
+                stmt.setNull(7, Types.TIMESTAMP);
+            }
+            stmt.setString(8, status);
+
+            return stmt.executeUpdate() > 0;
+        } catch (SQLException e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+}

--- a/src/main/java/gotcha/ui/GroupFormScreen.java
+++ b/src/main/java/gotcha/ui/GroupFormScreen.java
@@ -1,0 +1,170 @@
+package gotcha.ui;
+
+import gotcha.common.FontLoader;
+import gotcha.common.Session;
+import gotcha.dao.GroupDAO;
+
+import javax.swing.*;
+import javax.swing.text.*;
+import java.awt.*;
+import java.sql.Timestamp;
+
+public class GroupFormScreen extends JPanel {
+
+	private static final long serialVersionUID = 1L; //default
+
+	static class LengthRestrictedDocument extends PlainDocument {
+		
+		private static final long serialVersionUID = 1L; //default
+		private final int maxLength;
+
+        public LengthRestrictedDocument(int maxLength) {
+            this.maxLength = maxLength;
+        }
+
+        @Override
+        public void insertString(int offset, String str, AttributeSet attr) throws BadLocationException {
+            if (str == null) return;
+            if ((getLength() + str.length()) <= maxLength) {
+                super.insertString(offset, str, attr);
+            }
+        }
+    }
+
+    public GroupFormScreen() {
+        setLayout(new BorderLayout());
+        setBorder(BorderFactory.createEmptyBorder(30, 60, 30, 60));
+
+        // 제목
+        JLabel titleLabel = new JLabel("소모임 생성");
+        titleLabel.setFont(FontLoader.loadCustomFont(24f).deriveFont(Font.BOLD));
+        titleLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+
+        // 입력 필드들
+        JTextField titleField = new JTextField(20);
+        titleField.setDocument(new LengthRestrictedDocument(40));
+
+        JTextArea contextArea = new JTextArea(5, 20);
+
+        JTextField maxField = new JTextField(5);
+
+        String[] regions = {
+            "강남구", "강동구", "강북구", "강서구", "관악구", "광진구", "구로구", "금천구",
+            "노원구", "도봉구", "동대문구", "동작구", "마포구", "서대문구", "서초구",
+            "성동구", "성북구", "송파구", "양천구", "영등포구", "용산구", "은평구",
+            "종로구", "중구", "중랑구"
+        };
+        JComboBox<String> regionBox = new JComboBox<>(regions);
+
+        String[] categories = {
+            "봉사활동", "사교/인맥", "문화/공연/축제", "인문학/책/글", "공예/만들기",
+            "댄스/무용", "운동/스포츠", "외국/언어", "아웃도어/여행", "음악/악기",
+            "차/바이크", "사진/영상", "스포츠관람", "게임/오락", "요리/제조",
+            "반려동물", "자기계발", "테크/프로그래밍", "패션/뷰티", "수집/덕질"
+        };
+        JComboBox<String> categoryBox = new JComboBox<>(categories);
+
+        String[] statuses = { "모집중", "진행중", "진행완료" };
+        JComboBox<String> statusBox = new JComboBox<>(statuses);
+        statusBox.setSelectedItem("모집중");
+
+        JTextField deadlineField = new JTextField(20);
+
+        // 입력 폼 구성
+        JPanel formPanel = new JPanel();
+        formPanel.setLayout(new BoxLayout(formPanel, BoxLayout.Y_AXIS));
+        formPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+
+        formPanel.add(titleLabel);
+        formPanel.add(Box.createVerticalStrut(20));
+        formPanel.add(labeledField("제목:", titleField));
+        formPanel.add(Box.createVerticalStrut(10));
+        formPanel.add(labeledField("내용:", new JScrollPane(contextArea)));
+        formPanel.add(Box.createVerticalStrut(10));
+        formPanel.add(labeledField("최대 인원:", maxField));
+        formPanel.add(Box.createVerticalStrut(10));
+        formPanel.add(labeledField("지역:", regionBox));
+        formPanel.add(Box.createVerticalStrut(10));
+        formPanel.add(labeledField("카테고리:", categoryBox));
+        formPanel.add(Box.createVerticalStrut(10));
+        formPanel.add(labeledField("상태:", statusBox));
+        formPanel.add(Box.createVerticalStrut(10));
+        formPanel.add(labeledField("모집 마감일 (yyyy-MM-dd HH:mm:ss):", deadlineField));
+
+        add(formPanel, BorderLayout.CENTER);
+
+        // 제출 버튼
+        JButton submitBtn = new JButton("생성하기");
+        submitBtn.setFont(FontLoader.loadCustomFont(16f));
+        submitBtn.addActionListener(e -> {
+            String title = titleField.getText().trim();
+            String context = contextArea.getText().trim();
+
+            if (title.length() > 40) {
+                JOptionPane.showMessageDialog(this, "제목은 최대 40자까지 입력할 수 있습니다.");
+                return;
+            }
+
+            int max;
+            try {
+                max = Integer.parseInt(maxField.getText().trim());
+            } catch (NumberFormatException ex) {
+                JOptionPane.showMessageDialog(this, "최대 인원은 숫자여야 합니다.");
+                return;
+            }
+
+            String region = (String) regionBox.getSelectedItem();
+            String category = (String) categoryBox.getSelectedItem();
+            String status = (String) statusBox.getSelectedItem();
+            String deadlineText = deadlineField.getText().trim();
+
+            Timestamp deadline = null;
+            if (!deadlineText.isEmpty()) {
+                try {
+                    deadline = Timestamp.valueOf(deadlineText);
+                } catch (IllegalArgumentException ex) {
+                    JOptionPane.showMessageDialog(this, "마감일 형식이 잘못되었습니다.");
+                    return;
+                }
+            }
+
+            int hostId = Session.loggedInUserId; //기본: -1로 DB 삽입 안됨(오류)
+            //login 안된 상태에서 DB insert 실패 handling 하는 로직
+            //int hostId = Session.loggedInUserId != -1 ? Session.loggedInUserId : 1;
+
+            GroupDAO dao = new GroupDAO();
+            boolean success = dao.insertGroup(
+                hostId, title, context, max, region, category, deadline, status
+            );
+
+            if (success) {
+                JOptionPane.showMessageDialog(this, "소모임 생성 성공!");
+            } else {
+                JOptionPane.showMessageDialog(this, "소모임 생성 실패...");
+            }
+        });
+
+        JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.CENTER));
+        buttonPanel.add(submitBtn);
+        add(buttonPanel, BorderLayout.SOUTH);
+    }
+
+    // 라벨 + 필드를 수직으로 묶어주는 헬퍼
+    private JPanel labeledField(String labelText, JComponent field) {
+        JPanel panel = new JPanel();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+        panel.setAlignmentX(Component.LEFT_ALIGNMENT);
+
+        JLabel label = new JLabel(labelText);
+        label.setFont(FontLoader.loadCustomFont(14f));
+        label.setAlignmentX(Component.LEFT_ALIGNMENT);
+
+        field.setAlignmentX(Component.LEFT_ALIGNMENT);
+        panel.add(label);
+        panel.add(Box.createVerticalStrut(4));
+        panel.add(field);
+
+        return panel;
+    }
+}
+

--- a/src/main/java/gotcha/ui/HomeScreen.java
+++ b/src/main/java/gotcha/ui/HomeScreen.java
@@ -1,23 +1,49 @@
 package gotcha.ui;
 
+import gotcha.Main;
 import gotcha.common.FontLoader;
+
 import javax.swing.*;
 import java.awt.*;
 
 public class HomeScreen extends JPanel {
     public HomeScreen() {
-        setLayout(new GridLayout(2, 2, 20, 20));
+        setLayout(new BorderLayout());
+        FontLoader.applyGlobalFont(14f);
+
+        // 1. 상단 버튼 패널
+        JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.CENTER, 30, 30));
 
         JButton groupBtn = new JButton("소모임 탐색");
         JButton createBtn = new JButton("소모임 생성");
         JButton myPageBtn = new JButton("마이페이지");
 
-        groupBtn.setFont(FontLoader.loadCustomFont(16f));
-        createBtn.setFont(FontLoader.loadCustomFont(16f));
-        myPageBtn.setFont(FontLoader.loadCustomFont(16f));
+        Font btnFont = FontLoader.loadCustomFont(16f);
+        JButton[] buttons = {groupBtn, createBtn, myPageBtn};
+        for (JButton btn : buttons) {
+            btn.setFont(btnFont);
+            btn.setPreferredSize(new Dimension(140, 40));
+            buttonPanel.add(btn);
+        }
 
-        add(groupBtn);
-        add(createBtn);
-        add(myPageBtn);
+        // 2. 하단 이미지 패널
+        JLabel imageLabel;
+        try {
+            ImageIcon icon = new ImageIcon(getClass().getResource("/images/gatchi.png"));
+            Image scaled = icon.getImage().getScaledInstance(350, 350, Image.SCALE_SMOOTH); // 사이즈 조절
+            imageLabel = new JLabel(new ImageIcon(scaled));
+        } catch (Exception e) {
+            imageLabel = new JLabel("이미지를 불러올 수 없습니다.");
+        }
+        imageLabel.setHorizontalAlignment(SwingConstants.CENTER);
+        imageLabel.setVerticalAlignment(SwingConstants.CENTER);
+        imageLabel.setBorder(BorderFactory.createEmptyBorder(20, 0, 20, 0));
+
+        // 3. 화면 구성
+        add(buttonPanel, BorderLayout.NORTH);
+        add(imageLabel, BorderLayout.CENTER);
+
+        // 4. 버튼 이벤트 연결 (예시: 소모임 생성 → GroupFormScreen 전환)
+        createBtn.addActionListener(e -> Main.setScreen(new GroupFormScreen()));
     }
 }

--- a/src/test/java/gotcha/GroupFormScreenTest.java
+++ b/src/test/java/gotcha/GroupFormScreenTest.java
@@ -1,0 +1,15 @@
+package gotcha;
+
+import gotcha.ui.GroupFormScreen;
+
+import javax.swing.*;
+
+public class GroupFormScreenTest {
+    public static void main(String[] args) {
+        JFrame frame = new JFrame("테스트: 소모임 생성 화면");
+        frame.setSize(800, 600);
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.setContentPane(new GroupFormScreen());
+        frame.setVisible(true);
+    }
+}

--- a/src/test/java/gotcha/HomeScreenTest.java
+++ b/src/test/java/gotcha/HomeScreenTest.java
@@ -1,0 +1,28 @@
+package gotcha;
+
+import gotcha.common.FontLoader;
+import gotcha.ui.HomeScreen;
+
+import javax.swing.*;
+
+public class HomeScreenTest {
+    public static void main(String[] args) {
+        // 전역 폰트 설정 (선택사항)
+        FontLoader.applyGlobalFont(14f);
+
+        SwingUtilities.invokeLater(() -> {
+            // Main 클래스의 frame 직접 초기화
+            Main.frame = new JFrame("테스트: 홈 화면");
+            Main.frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+            Main.frame.setSize(800, 600);
+            Main.frame.setLocationRelativeTo(null); // 화면 가운데 정렬
+
+            // HomeScreen을 화면에 띄움
+            Main.setScreen(new HomeScreen());
+
+            // 화면 보여주기
+            Main.frame.setVisible(true);
+        });
+    }
+}
+


### PR DESCRIPTION
## 소모임 생성 기능 추가
![스크린샷 2025-05-21 020428](https://github.com/user-attachments/assets/ad6878dd-cf86-40e8-bc39-a5ed1a3295e5)
<GroupFormScreen 화면>

![스크린샷 2025-05-21 022055](https://github.com/user-attachments/assets/26a963c0-f72a-48cd-b943-b71705511671)
<HomeScreen 화면>

---

### common/Session.java 생성
- 소모임 생성할 때 host_id가 필요해서 간단한 로그인 세션 처리용 클래스 하나 만들어뒀어요!
- -1로 초기화해두었고,  나중에 다른 기능 개발하고 흐름 연결 때 로그인 연동하면 될 것 같습니당..

---

### dao/GroupDAO.java 생성
- class 테이블이랑 연결해서 insert하는 DAO class
- (class 예약어 -> group 사용)
- PreparedStatement로 insert 처리

---

### ui/GroupFormScreen.java 생성
- 소모임 만들기 화면 구성했습니다!
- 지역/카테고리/상태는 enum 으로 넣었고, title은 varchar(40)이라서 길이 제한 추가했습니다. (1L 초기화)
- 로그인 안 된 상태에서도 UI 확인 가능하게 host_id = -1로 우선 설정해두었고(근데 db insert 오류 날 거예요..), 
  테스트로 insert 해보고 싶으면 host_id를 1로 강제 설정하는 코드도 주석으로 남겨뒀어요!

+ GroupScreen은 나중에 소모임 관련 기능들 모아서 보여주는 화면으로 구성해도 좋을 것 같아요.

---

### ui/HomeScreen.java 수정
- 버튼 스타일 조금 바꾸고, 귀엽게.. 저희 마스코트 이미지(gotchi.png)도 하단에 넣어봤어요.. ㅎㅎ
- "소모임 생성" 버튼 누르면 `GroupFormScreen`으로 연결되도록 처리했습니다.

---

### 테스트
- `src/test/java` 밑에 `HomeScreenTest`, `GroupFormScreenTest` 생성
- 처음 추가된 사진과 같이 화면 출력 
- test용이므로 편하게 삭제하셔도 될 것 같습니다..
- 로그인 없이도 UI 흐름 확인할 수 있게 구성해봤습니다!

---

Closes #12
