### PR TITLE
[FEAT] 소모임 상세조회, 참여중인 모임 관리(작성, 수정, 삭제)

### DIFF
--- a/src/main/java/gotcha/dao/GroupDAO.java
+++ b/src/main/java/gotcha/dao/GroupDAO.java
@@ -186,9 +186,9 @@ public class GroupDAO {
     public List<Vector<String>> getGroupDetails(String keyword, String category) {
         List<Vector<String>> result = new ArrayList<>();
         StringBuilder sql = new StringBuilder(
-                "SELECT c.title, c.context, c.status, c.main_region " +
-                        "FROM class c " +
-                        "WHERE c.deleted_at IS NULL AND c.title LIKE ? "
+            "SELECT c.class_id, c.title, c.context, c.status, c.main_region " +
+            "FROM class c " +
+            "WHERE c.deleted_at IS NULL AND c.title LIKE ? "
         );
         if (!"전체".equals(category)) {
             sql.append("AND c.category = ? ");
@@ -206,6 +206,7 @@ public class GroupDAO {
             ResultSet rs = ps.executeQuery();
             while (rs.next()) {
                 Vector<String> row = new Vector<>();
+                row.add(String.valueOf(rs.getInt("class_id"))); // classId 추가
                 row.add(rs.getString("title"));
                 row.add(rs.getString("context"));
                 row.add(rs.getString("status"));
@@ -217,6 +218,7 @@ public class GroupDAO {
         }
         return result;
     }
+
 
     public List<Vector<String>> selectGroupsByHost(int hostId) {
         List<Vector<String>> result = new ArrayList<>();
@@ -273,6 +275,32 @@ public class GroupDAO {
         return null;
     }
 
+    public Vector<String> getGroupDetailScreen(int classId) {
+        String sql = "SELECT title, category, context, main_region, status " +
+                     "FROM class WHERE class_id = ? AND deleted_at IS NULL";
+
+        try (Connection conn = DBConnector.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+
+            ps.setInt(1, classId);
+            ResultSet rs = ps.executeQuery();
+
+            if (rs.next()) {
+                Vector<String> row = new Vector<>();
+                row.add(rs.getString("title"));
+                row.add(rs.getString("category"));
+                row.add(rs.getString("context"));
+                row.add(rs.getString("main_region"));
+                row.add(rs.getString("status"));
+                return row;
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    
 	public boolean markGroupAsDeleted(int classId) {
 		String sql = "UPDATE class SET deleted_at = NOW() WHERE class_id = ?";
 	    try (Connection conn = DBConnector.getConnection();

--- a/src/main/java/gotcha/dao/GroupDAO.java
+++ b/src/main/java/gotcha/dao/GroupDAO.java
@@ -310,5 +310,33 @@ public class GroupDAO {
 	        return false;
 	    }
 	}
+
+    public boolean isAlreadyJoined(int userId, int classId) {
+        String sql = "SELECT COUNT(*) FROM participation WHERE user_id = ? AND class_id = ?";
+        try (Connection conn = DBConnector.getConnection();
+             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            pstmt.setInt(1, userId);
+            pstmt.setInt(2, classId);
+            ResultSet rs = pstmt.executeQuery();
+            return rs.next() && rs.getInt(1) > 0;
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
+
+    public int insertParticipation(int userId, int classId, Timestamp joinedAt) {
+        String sql = "INSERT INTO participation(user_id, class_id, joined_at) VALUES (?, ?, ?)";
+        try (Connection conn = DBConnector.getConnection();
+             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            pstmt.setInt(1, userId);
+            pstmt.setInt(2, classId);
+            pstmt.setTimestamp(3, joinedAt);
+            return pstmt.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return 0;
+    }
 }
 

--- a/src/main/java/gotcha/dao/ParticipantDAO.java
+++ b/src/main/java/gotcha/dao/ParticipantDAO.java
@@ -1,0 +1,35 @@
+package gotcha.dao;
+
+import gotcha.common.DBConnector;
+import gotcha.dto.Participant;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ParticipantDAO {
+    public List<Participant> getParticipants(int classId, int writerId) {
+        List<Participant> result = new ArrayList<>();
+        String sql = "SELECT u.user_id, u.nickname " +
+                     "FROM participation p " +
+                     "JOIN user u ON p.user_id = u.user_id " +
+                     "WHERE p.class_id = ? AND u.user_id != ?";
+
+        try (Connection conn = DBConnector.getConnection();
+             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            pstmt.setInt(1, classId);
+            pstmt.setInt(2, writerId);
+            ResultSet rs = pstmt.executeQuery();
+            while (rs.next()) {
+                result.add(new Participant(
+                    rs.getInt("user_id"),
+                    rs.getString("nickname")
+                ));
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/gotcha/dao/ParticipantReviewDAO.java
+++ b/src/main/java/gotcha/dao/ParticipantReviewDAO.java
@@ -1,0 +1,129 @@
+package gotcha.dao;
+
+import gotcha.common.DBConnector;
+import gotcha.dto.ParticipantReview;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ParticipantReviewDAO {
+
+    // 특정 참여자(targetId)에 대해 받은 모든 리뷰 조회
+    public List<ParticipantReview> getReviewsForParticipant(int classId, int targetId) {
+        List<ParticipantReview> result = new ArrayList<>();
+        String sql = "SELECT review_id, rating, content FROM review " +
+                     "WHERE class_id = ? AND target_id = ? " +
+                     "ORDER BY review_id DESC";
+        try (Connection conn = DBConnector.getConnection();
+             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            pstmt.setInt(1, classId);
+            pstmt.setInt(2, targetId);
+            ResultSet rs = pstmt.executeQuery();
+            while (rs.next()) {
+                result.add(new ParticipantReview(
+                    rs.getInt("review_id"),
+                    rs.getFloat("rating"),
+                    rs.getString("content")
+                ));
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return result;
+    }
+
+    // 특정 참여자에 대해 내가 쓴 리뷰 1개 조회
+    public ParticipantReview getReview(int classId, int writerId, int targetId) {
+        String sql = "SELECT review_id, rating, content FROM review " +
+                     "WHERE class_id = ? AND writer_id = ? AND target_id = ?";
+        try (Connection conn = DBConnector.getConnection();
+             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            pstmt.setInt(1, classId);
+            pstmt.setInt(2, writerId);
+            pstmt.setInt(3, targetId);
+            ResultSet rs = pstmt.executeQuery();
+            if (rs.next()) {
+                return new ParticipantReview(
+                    rs.getInt("review_id"),
+                    rs.getFloat("rating"),
+                    rs.getString("content")
+                );
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    // 리뷰 작성
+    public boolean writeReview(int classId, int writerId, int targetId, float rating, String content) {
+        String sql = "INSERT INTO review(class_id, writer_id, target_id, rating, content) " +
+                     "VALUES (?, ?, ?, ?, ?)";
+        try (Connection conn = DBConnector.getConnection();
+             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            pstmt.setInt(1, classId);
+            pstmt.setInt(2, writerId);
+            pstmt.setInt(3, targetId);
+            pstmt.setFloat(4, rating);
+            pstmt.setString(5, content);
+            int rows = pstmt.executeUpdate();
+            return rows > 0;
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
+
+    // 리뷰 수정
+    public boolean updateReview(int reviewId, float rating, String content) {
+        String sql = "UPDATE review SET rating = ?, content = ? WHERE review_id = ?";
+        try (Connection conn = DBConnector.getConnection();
+             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            pstmt.setFloat(1, rating);
+            pstmt.setString(2, content);
+            pstmt.setInt(3, reviewId);
+            int rows = pstmt.executeUpdate();
+            return rows > 0;
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
+
+    // 리뷰 삭제
+    public boolean deleteReview(int reviewId) {
+        String sql = "DELETE FROM review WHERE review_id = ?";
+        try (Connection conn = DBConnector.getConnection();
+             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            pstmt.setInt(1, reviewId);
+            int rows = pstmt.executeUpdate();
+            return rows > 0;
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
+
+    // 특정 class, writer, target 조합의 리뷰 존재 여부 확인
+    public boolean reviewExists(int classId, int writerId, int targetId) {
+        String sql = "SELECT COUNT(*) FROM review " +
+                     "WHERE class_id = ? AND writer_id = ? AND target_id = ?";
+        try (Connection conn = DBConnector.getConnection();
+             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            pstmt.setInt(1, classId);
+            pstmt.setInt(2, writerId);
+            pstmt.setInt(3, targetId);
+            ResultSet rs = pstmt.executeQuery();
+            if (rs.next()) {
+                return rs.getInt(1) > 0;
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
+
+
+}
+

--- a/src/main/java/gotcha/dao/PublicGroupDAO.java
+++ b/src/main/java/gotcha/dao/PublicGroupDAO.java
@@ -8,7 +8,7 @@ import java.sql.*;
 public class PublicGroupDAO {
     public PublicGroup getPublicGroupById(int classId) {
         String sql =
-            "SELECT c.class_id, c.title, c.category, c.context, c.main_region, u.nickname AS host_nickname, " +
+            "SELECT c.class_id, c.host_id, c.title, c.category, c.context, c.main_region, u.nickname AS host_nickname, " +
             "  (SELECT GROUP_CONCAT(DISTINCT CASE s.day_of_week " +
             "      WHEN 'Mon' THEN '월' WHEN 'Tues' THEN '화' WHEN 'Wed' THEN '수' " +
             "      WHEN 'Thur' THEN '목' WHEN 'Fri' THEN '금' WHEN 'Sat' THEN '토' WHEN 'Sun' THEN '일' " +
@@ -29,6 +29,7 @@ public class PublicGroupDAO {
             if (rs.next()) {
                 return new PublicGroup(
                     rs.getInt("class_id"),
+                    rs.getInt("host_id"),
                     rs.getString("title"),
                     rs.getString("category"),
                     rs.getString("context"),

--- a/src/main/java/gotcha/dao/ReviewDAO.java
+++ b/src/main/java/gotcha/dao/ReviewDAO.java
@@ -1,0 +1,55 @@
+package gotcha.dao;
+
+import gotcha.common.DBConnector;
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ReviewDAO {
+
+    // 주최자 리뷰 정보를 담는 내부 클래스
+    public static class HostReview {
+        private String reviewerName; // 리뷰 작성자 이름
+        private float rating;
+        private String content;      // 리뷰 내용
+
+        public HostReview(String reviewerName, float rating, String content) {
+            this.reviewerName = reviewerName;
+            this.rating = rating;
+            this.content = content;
+        }
+
+        public String getReviewerName() { return reviewerName; }
+        public float getRating() { return rating; }
+        public String getContent() { return content; }
+    }
+
+    // 특정 classId에 해당하는 주최자에 대한 리뷰들을 반환
+    public List<HostReview> getHostReviewsByClassId(int classId) {
+        List<HostReview> result = new ArrayList<>();
+        String sql =
+            "SELECT u.nickname AS reviewer, r.rating, r.content AS comment " +
+            "FROM review r " +
+            "JOIN user u ON r.writer_id = u.user_id " +
+            "WHERE r.class_id = ? AND r.target_id = (" +
+            "    SELECT host_id FROM class WHERE class_id = ?" +
+            ")";
+
+        try (Connection conn = DBConnector.getConnection();
+             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            pstmt.setInt(1, classId);
+            pstmt.setInt(2, classId);
+            ResultSet rs = pstmt.executeQuery();
+            while (rs.next()) {
+                result.add(new HostReview(
+                    rs.getString("reviewer"),
+                    rs.getFloat("rating"),
+                    rs.getString("comment")
+                ));
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return result;
+    }
+}

--- a/src/main/java/gotcha/dao/ScrapDAO.java
+++ b/src/main/java/gotcha/dao/ScrapDAO.java
@@ -53,4 +53,48 @@ public class ScrapDAO {
 	    }
 	    return false;
 	}
+	
+	//상세 조회용 화면 
+	public boolean isScrapped(int userId, int classId) {
+	    String sql = "SELECT COUNT(*) FROM scrap WHERE user_id = ? AND class_id = ? AND deleted_at IS NULL";
+	    try (Connection conn = DBConnector.getConnection();
+	         PreparedStatement pstmt = conn.prepareStatement(sql)) {
+	        pstmt.setInt(1, userId);
+	        pstmt.setInt(2, classId);
+	        ResultSet rs = pstmt.executeQuery();
+	        return rs.next() && rs.getInt(1) > 0;
+	    } catch (SQLException e) {
+	        e.printStackTrace();
+	    }
+	    return false;
+	}
+	
+	public boolean scrapClass(int userId, int classId) {
+	    String updateSql = "UPDATE scrap SET deleted_at = NULL WHERE user_id = ? AND class_id = ?";
+	    String insertSql = "INSERT INTO scrap(user_id, class_id) VALUES (?, ?)";
+
+	    try (Connection conn = DBConnector.getConnection()) {
+	        // 먼저 복구 시도 (soft delete 취소)
+	        try (PreparedStatement updateStmt = conn.prepareStatement(updateSql)) {
+	            updateStmt.setInt(1, userId);
+	            updateStmt.setInt(2, classId);
+	            if (updateStmt.executeUpdate() > 0) {
+	                return true;
+	            }
+	        }
+
+	        // 없으면 새로 insert
+	        try (PreparedStatement insertStmt = conn.prepareStatement(insertSql)) {
+	            insertStmt.setInt(1, userId);
+	            insertStmt.setInt(2, classId);
+	            return insertStmt.executeUpdate() > 0;
+	        }
+
+	    } catch (SQLException e) {
+	        e.printStackTrace();
+	    }
+
+	    return false;
+	}
+
 }

--- a/src/main/java/gotcha/dto/Participant.java
+++ b/src/main/java/gotcha/dto/Participant.java
@@ -1,0 +1,19 @@
+package gotcha.dto;
+
+public class Participant {
+    private int userId;
+    private String nickname;
+
+    public Participant(int userId, String nickname) {
+        this.userId = userId;
+        this.nickname = nickname;
+    }
+
+    public int getUserId() { return userId; }
+    public String getNickname() { return nickname; }
+
+    @Override
+    public String toString() {
+        return nickname;
+    }
+}

--- a/src/main/java/gotcha/dto/ParticipantReview.java
+++ b/src/main/java/gotcha/dto/ParticipantReview.java
@@ -1,0 +1,28 @@
+package gotcha.dto;
+
+public class ParticipantReview {
+    private int reviewId;
+    private float rating;
+    private String content;
+
+    // 생성자
+    public ParticipantReview(int reviewId, float rating, String content) {
+        this.reviewId = reviewId;
+        this.rating = rating;
+        this.content = content;
+    }
+
+    // Getter
+    public int getReviewId() {
+        return reviewId;
+    }
+
+    public float getRating() {
+        return rating;
+    }
+
+    public String getContent() {
+        return content;
+    }
+}
+

--- a/src/main/java/gotcha/dto/PublicGroup.java
+++ b/src/main/java/gotcha/dto/PublicGroup.java
@@ -2,6 +2,7 @@ package gotcha.dto;
 
 public class PublicGroup {
     private int classId;
+    private int hostId;
     private String title;
     private String category;
     private String context;
@@ -13,10 +14,11 @@ public class PublicGroup {
     private String status;
 
     // 전체 필드를 받는 생성자
-    public PublicGroup(int classId, String title, String category, String context,
+    public PublicGroup(int classId, int hostId, String title, String category, String context,
                        String region, String hostNickname, String days,
                        int userCount, int max, String status) {
         this.classId = classId;
+        this.hostId = hostId;
         this.title = title;
         this.category = category;
         this.context = context;
@@ -29,6 +31,7 @@ public class PublicGroup {
     }
 
     public int getClassId() { return classId; }
+    public int getHostId() {return hostId; }
     public String getTitle() { return title; }
     public String getCategory() { return category; }
     public String getContext() { return context; }

--- a/src/main/java/gotcha/service/HomeService.java
+++ b/src/main/java/gotcha/service/HomeService.java
@@ -1,6 +1,8 @@
 package gotcha.service;
 
 import gotcha.dao.GroupDAO;
+import gotcha.dao.PublicGroupDAO;
+import gotcha.dto.PublicGroup;
 
 import javax.swing.table.DefaultTableModel;
 import java.util.List;
@@ -26,11 +28,17 @@ public class HomeService {
         }
     }
 
+    public PublicGroup getGroupDetailScreen(int classId) {
+        PublicGroupDAO dao = new PublicGroupDAO();
+        return dao.getPublicGroupById(classId);
+    }
 
-    public void loadGroupDetails(DefaultTableModel mainModel, String keyword, String category) {
+    
+    public List<Vector<String>> loadGroupDetails(DefaultTableModel mainModel, String keyword, String category) {
         List<Vector<String>> groups = dao.getGroupDetails(keyword, category);
         for (Vector<String> row : groups) {
             mainModel.addRow(row);
         }
+        return groups;
     }
 }

--- a/src/main/java/gotcha/service/JoinService.java
+++ b/src/main/java/gotcha/service/JoinService.java
@@ -1,34 +1,19 @@
 package gotcha.service;
 
-import gotcha.common.DBConnector;
-import java.sql.*;
+import gotcha.dao.GroupDAO;
+
+import java.sql.Timestamp;
 
 public class JoinService {
 
+    private final GroupDAO dao = new GroupDAO();
+
     public boolean isAlreadyJoined(int userId, int classId) {
-        String sql = "SELECT COUNT(*) FROM participation WHERE user_id = ? AND class_id = ?";
-        try (Connection conn = DBConnector.getConnection();
-             PreparedStatement pstmt = conn.prepareStatement(sql)) {
-            pstmt.setInt(1, userId);
-            pstmt.setInt(2, classId);
-            ResultSet rs = pstmt.executeQuery();
-            return rs.next() && rs.getInt(1) > 0;
-        } catch (SQLException e) {
-            e.printStackTrace();
-        }
-        return false;
+        return dao.isAlreadyJoined(userId, classId);
     }
 
     public int joinClass(int userId, int classId) {
-        String sql = "INSERT INTO participation(user_id, class_id) VALUES (?, ?)";
-        try (Connection conn = DBConnector.getConnection();
-             PreparedStatement pstmt = conn.prepareStatement(sql)) {
-            pstmt.setInt(1, userId);
-            pstmt.setInt(2, classId);
-            return pstmt.executeUpdate();
-        } catch (SQLException e) {
-            e.printStackTrace();
-        }
-        return 0;
+        Timestamp now = new Timestamp(System.currentTimeMillis());
+        return dao.insertParticipation(userId, classId, now);
     }
 }

--- a/src/main/java/gotcha/service/JoinService.java
+++ b/src/main/java/gotcha/service/JoinService.java
@@ -1,0 +1,34 @@
+package gotcha.service;
+
+import gotcha.common.DBConnector;
+import java.sql.*;
+
+public class JoinService {
+
+    public boolean isAlreadyJoined(int userId, int classId) {
+        String sql = "SELECT COUNT(*) FROM participation WHERE user_id = ? AND class_id = ?";
+        try (Connection conn = DBConnector.getConnection();
+             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            pstmt.setInt(1, userId);
+            pstmt.setInt(2, classId);
+            ResultSet rs = pstmt.executeQuery();
+            return rs.next() && rs.getInt(1) > 0;
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
+
+    public int joinClass(int userId, int classId) {
+        String sql = "INSERT INTO participation(user_id, class_id) VALUES (?, ?)";
+        try (Connection conn = DBConnector.getConnection();
+             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            pstmt.setInt(1, userId);
+            pstmt.setInt(2, classId);
+            return pstmt.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return 0;
+    }
+}

--- a/src/main/java/gotcha/service/ParticipantReviewService.java
+++ b/src/main/java/gotcha/service/ParticipantReviewService.java
@@ -1,0 +1,22 @@
+package gotcha.service;
+
+import gotcha.dao.ParticipantReviewDAO;
+import gotcha.dto.ParticipantReview; 
+import java.util.List;
+
+public class ParticipantReviewService {
+
+    private ParticipantReviewDAO dao = new ParticipantReviewDAO();
+
+    public List<ParticipantReview> getReviewsForParticipant(int classId, int targetId) {
+        return dao.getReviewsForParticipant(classId, targetId);
+    }
+
+    public boolean writeReview(int classId, int writerId, int targetId, float rating, String content) {
+        return dao.writeReview(classId, writerId, targetId, rating, content);
+    }
+
+    public boolean reviewExists(int classId, int writerId, int targetId) {
+        return dao.reviewExists(classId, writerId, targetId);
+    }
+}

--- a/src/main/java/gotcha/service/ScrapService.java
+++ b/src/main/java/gotcha/service/ScrapService.java
@@ -18,4 +18,13 @@ public class ScrapService {
 	public boolean cancelScrap(int userId, int classId) {
         return scrapDAO.cancelScrap(userId, classId);
     }
+	
+	public boolean isScrapped(int userId, int classId) {
+	    return scrapDAO.isScrapped(userId, classId);
+	}
+	
+	public boolean scrapClass(int userId, int classId) {
+	    return scrapDAO.scrapClass(userId, classId);
+	}
+
 }

--- a/src/main/java/gotcha/service/UserService.java
+++ b/src/main/java/gotcha/service/UserService.java
@@ -40,4 +40,9 @@ public class UserService {
         return userDAO.updateUserInfo(userId, newNickname, newEmail, newRegion);
     }
 
+	public String getNicknameById(int id) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
 }

--- a/src/main/java/gotcha/ui/home/HomeScreen.java
+++ b/src/main/java/gotcha/ui/home/HomeScreen.java
@@ -25,11 +25,8 @@ public class HomeScreen extends JPanel {
     private JComboBox<String> categoryToggle;
     private JTextField searchField;
     private final HomeService service = new HomeService();
-<<<<<<< HEAD
     private List<Vector<String>> currentGroupData;
-=======
     private final ScrapService scrapService = new ScrapService();
->>>>>>> origin
 
     public HomeScreen() {
         FontLoader.applyGlobalFont(14f);
@@ -54,12 +51,8 @@ public class HomeScreen extends JPanel {
         searchCategoryPanel.add(searchPanel, BorderLayout.WEST);
         searchCategoryPanel.add(categoryPanel, BorderLayout.EAST);
 
-<<<<<<< HEAD
-        JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 10, 10));
-=======
-        // 하단 버튼 왼쪽 (create, manage, board, region/gender)
+          // 하단 버튼 왼쪽 (create, manage, board, region/gender)
         JPanel leftButtonPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 10, 10));
->>>>>>> origin
         JButton createBtn = new JButton("소모임 생성");
         JButton manageBtn = new JButton("소모임 관리");
         JButton boardBtn = new JButton("게시판");
@@ -87,7 +80,6 @@ public class HomeScreen extends JPanel {
         JPanel centerPanel = new JPanel();
         centerPanel.setLayout(new BoxLayout(centerPanel, BoxLayout.Y_AXIS));
 
-<<<<<<< HEAD
         DefaultTableModel initialMainModel = new DefaultTableModel();
         initialMainModel.setColumnIdentifiers(new String[]{"소모임 이름", "소개", "상태", "지역"});
         groupTable = new JTable(initialMainModel) {
@@ -96,12 +88,10 @@ public class HomeScreen extends JPanel {
                 return false;
             }
         };
-=======
-        JLabel hintLabel = new JLabel("※ 소모임을 더블클릭하면 스크랩할 수 있습니다.");
+        JLabel hintLabel = new JLabel("※ 소모임을 더블클릭하면 상세조회할 수 있습니다.");
         hintLabel.setForeground(Color.GRAY);
         hintLabel.setFont(hintLabel.getFont().deriveFont(Font.ITALIC, 12f));
         centerPanel.add(hintLabel);
->>>>>>> origin
 
         JScrollPane tableScroll = new JScrollPane(groupTable);
 
@@ -133,12 +123,8 @@ public class HomeScreen extends JPanel {
         searchBtn.addActionListener(e -> refreshTables());
         categoryToggle.addActionListener(e -> refreshTables());
         regionGenderBtn.addActionListener(e -> Main.setScreen(new RegionGenderScreen()));
-
-<<<<<<< HEAD
-=======
         mainPanel.add(buttonPanel, BorderLayout.SOUTH);
 
->>>>>>> origin
         myPageBtn.addActionListener(e -> {
             if (userId != -1) {
                 Main.setScreen(new MyPageScreen(userId));
@@ -162,7 +148,7 @@ public class HomeScreen extends JPanel {
 
 
         refreshTables();
-
+        /*
         groupTable.addMouseListener(new java.awt.event.MouseAdapter() {
             @Override
             public void mouseClicked(java.awt.event.MouseEvent evt) {
@@ -188,25 +174,20 @@ public class HomeScreen extends JPanel {
                 }
             }
         });
-
+    */
 
     }
 
     private void refreshTables() {
-<<<<<<< HEAD
-        DefaultTableModel mainModel = new DefaultTableModel();
-        mainModel.setColumnIdentifiers(new String[]{"ID", "소모임 이름", "소개", "상태", "지역"});
-        currentGroupData = service.loadGroupDetails(mainModel, searchField.getText(), (String) categoryToggle.getSelectedItem());
-=======
         DefaultTableModel mainModel = new DefaultTableModel() {
             @Override
             public boolean isCellEditable(int row, int column) {
                 return false;
             }
         };
-        mainModel.setColumnIdentifiers(new String[]{"class_id", "소모임 이름", "소개", "상태", "지역"}); // class_id 포함
-
+        mainModel.setColumnIdentifiers(new String[]{"class_id", "소모임 이름", "소개", "상태", "지역"});
         service.loadGroupDetails(mainModel, searchField.getText(), (String) categoryToggle.getSelectedItem());
+        currentGroupData = service.loadGroupDetails(mainModel, searchField.getText(), (String) categoryToggle.getSelectedItem());
 
         groupTable.setModel(mainModel);
         groupTable.getColumnModel().getColumn(0).setMinWidth(0);
@@ -214,24 +195,11 @@ public class HomeScreen extends JPanel {
         groupTable.getColumnModel().getColumn(0).setWidth(0);
 
         service.loadGroupDetails(mainModel, searchField.getText(), (String) categoryToggle.getSelectedItem());
->>>>>>> origin
 
-        groupTable.setModel(mainModel);
-        groupTable.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
-
-        // ID 컬럼 숨기기
-        groupTable.getColumnModel().getColumn(0).setMinWidth(0);
-        groupTable.getColumnModel().getColumn(0).setMaxWidth(0);
-        groupTable.getColumnModel().getColumn(0).setWidth(0);
-        
         DefaultTableModel top5Model = new DefaultTableModel();
         top5Model.setColumnIdentifiers(new String[]{"순위", "소모임 이름", "출석률", "모임 설명"});
         service.loadGroupAttendance(top5Model, searchField.getText(), (String) categoryToggle.getSelectedItem());
 
-<<<<<<< HEAD
-        top5Table.setModel(top5Model);
-        top5Table.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
-=======
         // groupTable.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
         // top5Table.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
 
@@ -246,6 +214,5 @@ public class HomeScreen extends JPanel {
         top5Table.getColumnModel().getColumn(1).setPreferredWidth(150);
         top5Table.getColumnModel().getColumn(2).setPreferredWidth(80);
         top5Table.getColumnModel().getColumn(3).setPreferredWidth(400);
->>>>>>> origin
     }
 }

--- a/src/main/java/gotcha/ui/home/OtherGroupDetailScreen.java
+++ b/src/main/java/gotcha/ui/home/OtherGroupDetailScreen.java
@@ -4,6 +4,8 @@ import gotcha.Main;
 import gotcha.common.FontLoader;
 import gotcha.dao.PublicGroupDAO;
 import gotcha.dto.PublicGroup;
+import gotcha.service.JoinService;
+import gotcha.service.ScrapService;
 
 import javax.swing.*;
 import javax.swing.border.*;
@@ -12,33 +14,38 @@ import java.awt.*;
 public class OtherGroupDetailScreen extends JPanel {
     private PublicGroup group;
     private int userId;
+    private ScrapService scrapService = new ScrapService();
+    private boolean isScrapped = false;
+    private JButton scrapBtn;
 
+    // 기존 생성자: classId만 받음 → 내부에서 group 조회
     public OtherGroupDetailScreen(int classId, int userId) {
+        this(new PublicGroupDAO().getPublicGroupById(classId), userId);
+    }
+
+    // 새로운 생성자: 이미 PublicGroup 객체를 받은 경우
+    public OtherGroupDetailScreen(PublicGroup group, int userId) {
+        this.group = group;
         this.userId = userId;
         setLayout(new BorderLayout());
-
-        // 데이터 조회
-        PublicGroupDAO dao = new PublicGroupDAO();
-        group = dao.getPublicGroupById(classId);
 
         if (group == null) {
             JOptionPane.showMessageDialog(this, "소모임 정보를 불러올 수 없습니다.");
             return;
         }
 
-        // 제목
+        isScrapped = scrapService.isScrapped(userId, group.getClassId());
+
         JLabel titleLabel = new JLabel(group.getTitle());
         titleLabel.setFont(FontLoader.loadCustomFont(24f).deriveFont(Font.BOLD));
         titleLabel.setBorder(BorderFactory.createEmptyBorder(20, 20, 10, 20));
         add(titleLabel, BorderLayout.NORTH);
 
-        // 카드 패널
         JPanel cardPanel = new JPanel();
         cardPanel.setLayout(new BoxLayout(cardPanel, BoxLayout.Y_AXIS));
         cardPanel.setBorder(BorderFactory.createEmptyBorder(10, 20, 20, 20));
         cardPanel.setBackground(Color.WHITE);
 
-        // 카드 내용
         cardPanel.add(createInfoCard("카테고리", group.getCategory()));
         cardPanel.add(Box.createVerticalStrut(10));
         cardPanel.add(createInfoCard("소개", group.getContext()));
@@ -54,8 +61,6 @@ public class OtherGroupDetailScreen extends JPanel {
         cardPanel.add(createInfoCard("주최자", group.getHostNickname()));
 
         add(cardPanel, BorderLayout.CENTER);
-
-        // 버튼
         add(createButtonPanel(), BorderLayout.SOUTH);
     }
 
@@ -75,29 +80,54 @@ public class OtherGroupDetailScreen extends JPanel {
 
         panel.add(labelComponent, BorderLayout.WEST);
         panel.add(valueComponent, BorderLayout.EAST);
-
         return panel;
     }
 
     private JPanel createButtonPanel() {
         JPanel panel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
-        JButton scrapBtn = new JButton("스크랩하기");
+        scrapBtn = new JButton(isScrapped ? "스크랩 취소" : "스크랩하기");
         JButton joinBtn = new JButton("가입하기");
         JButton backBtn = new JButton("뒤로가기");
 
         scrapBtn.addActionListener(e -> {
-            // TODO: 스크랩 로직 추가
-            JOptionPane.showMessageDialog(this, "스크랩 되었습니다!");
+            boolean success;
+            if (isScrapped) {
+                success = scrapService.cancelScrap(userId, group.getClassId());
+                if (success) {
+                    isScrapped = false;
+                    scrapBtn.setText("스크랩하기");
+                    JOptionPane.showMessageDialog(this, "스크랩이 취소되었습니다.");
+                }
+            } else {
+                success = scrapService.scrapClass(userId, group.getClassId());
+                if (success) {
+                    isScrapped = true;
+                    scrapBtn.setText("스크랩 취소");
+                    JOptionPane.showMessageDialog(this, "스크랩 되었습니다!");
+                }
+            }
         });
 
-        joinBtn.addActionListener(e -> {
-            // TODO: 가입 로직 추가
-            JOptionPane.showMessageDialog(this, "가입 신청 완료!");
-        });
+        JoinService joinService = new JoinService();
+        boolean alreadyJoined = joinService.isAlreadyJoined(userId, group.getClassId());
 
-        backBtn.addActionListener(e -> {
-            Main.setScreen(new HomeScreen());
-        });
+        if (alreadyJoined) {
+            joinBtn.setText("이미 가입됨");
+            joinBtn.setEnabled(false);
+        } else {
+            joinBtn.addActionListener(e -> {
+                int result = joinService.joinClass(userId, group.getClassId());
+                if (result > 0) {
+                    JOptionPane.showMessageDialog(this, "가입 신청 완료!");
+                    joinBtn.setEnabled(false);
+                    joinBtn.setText("가입 완료");
+                } else {
+                    JOptionPane.showMessageDialog(this, "가입 처리 중 문제가 발생했습니다.");
+                }
+            });
+        }
+
+        backBtn.addActionListener(e -> Main.setScreen(new HomeScreen()));
 
         panel.add(scrapBtn);
         panel.add(joinBtn);
@@ -105,3 +135,4 @@ public class OtherGroupDetailScreen extends JPanel {
         return panel;
     }
 }
+

--- a/src/main/java/gotcha/ui/home/OtherGroupDetailScreen.java
+++ b/src/main/java/gotcha/ui/home/OtherGroupDetailScreen.java
@@ -7,12 +7,12 @@ import gotcha.dto.PublicGroup;
 import gotcha.service.JoinService;
 import gotcha.service.ScrapService;
 import gotcha.ui.review.HostReviewScreen;
-import gotcha.ui.review.UserReviewScreen;
+import gotcha.ui.review.ParticipantReviewWriteScreen;
+import gotcha.ui.review.ViewParticipantReviewScreen;
 
 import javax.swing.*;
 import javax.swing.border.*;
 import java.awt.*;
-import java.security.Provider.Service;
 
 public class OtherGroupDetailScreen extends JPanel {
     private PublicGroup group;
@@ -21,12 +21,10 @@ public class OtherGroupDetailScreen extends JPanel {
     private boolean isScrapped = false;
     private JButton scrapBtn;
 
-    // 기존 생성자: classId만 받음 → 내부에서 group 조회
     public OtherGroupDetailScreen(int classId, int userId) {
         this(new PublicGroupDAO().getPublicGroupById(classId), userId);
     }
 
-    // 새로운 생성자: 이미 PublicGroup 객체를 받은 경우
     public OtherGroupDetailScreen(PublicGroup group, int userId) {
         this.group = group;
         this.userId = userId;
@@ -120,9 +118,16 @@ public class OtherGroupDetailScreen extends JPanel {
         JoinService joinService = new JoinService();
         boolean alreadyJoined = joinService.isAlreadyJoined(userId, group.getClassId());
 
+        // 조건: 참여자일 경우 "참여자 리뷰 쓰기" 버튼 보여줌
         if (alreadyJoined) {
             joinBtn.setText("이미 가입됨");
             joinBtn.setEnabled(false);
+
+            JButton reviewBtn = new JButton("참여자 리뷰 쓰기");
+            reviewBtn.addActionListener(e -> {
+                Main.setScreen(new ViewParticipantReviewScreen(group.getClassId(), userId));
+            });
+            panel.add(reviewBtn);
         } else {
             joinBtn.addActionListener(e -> {
                 int result = joinService.joinClass(userId, group.getClassId());
@@ -145,4 +150,5 @@ public class OtherGroupDetailScreen extends JPanel {
         return panel;
     }
 }
+
 

--- a/src/main/java/gotcha/ui/home/OtherGroupDetailScreen.java
+++ b/src/main/java/gotcha/ui/home/OtherGroupDetailScreen.java
@@ -6,10 +6,13 @@ import gotcha.dao.PublicGroupDAO;
 import gotcha.dto.PublicGroup;
 import gotcha.service.JoinService;
 import gotcha.service.ScrapService;
+import gotcha.ui.review.HostReviewScreen;
+import gotcha.ui.review.UserReviewScreen;
 
 import javax.swing.*;
 import javax.swing.border.*;
 import java.awt.*;
+import java.security.Provider.Service;
 
 public class OtherGroupDetailScreen extends JPanel {
     private PublicGroup group;
@@ -85,9 +88,15 @@ public class OtherGroupDetailScreen extends JPanel {
 
     private JPanel createButtonPanel() {
         JPanel panel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        JButton hostReviewBtn = new JButton("주최자 리뷰 조회");
         scrapBtn = new JButton(isScrapped ? "스크랩 취소" : "스크랩하기");
         JButton joinBtn = new JButton("가입하기");
         JButton backBtn = new JButton("뒤로가기");
+
+        hostReviewBtn.addActionListener(e -> {
+            JFrame parentFrame = (JFrame) SwingUtilities.getWindowAncestor(this);
+            new HostReviewScreen(parentFrame, group.getClassId()).setVisible(true);
+        });
 
         scrapBtn.addActionListener(e -> {
             boolean success;
@@ -129,6 +138,7 @@ public class OtherGroupDetailScreen extends JPanel {
 
         backBtn.addActionListener(e -> Main.setScreen(new HomeScreen()));
 
+        panel.add(hostReviewBtn);
         panel.add(scrapBtn);
         panel.add(joinBtn);
         panel.add(backBtn);

--- a/src/main/java/gotcha/ui/mypage/MyPageScreen.java
+++ b/src/main/java/gotcha/ui/mypage/MyPageScreen.java
@@ -4,9 +4,9 @@ import gotcha.service.UserService;
 import gotcha.service.UserRatingService;
 import gotcha.ui.CurrentGroupScreen;
 import gotcha.ui.home.HomeScreen;
-import gotcha.ui.UserReviewScreen;
 import gotcha.ui.mypage.PreviousClassesPanel;
 import gotcha.ui.mypage.ScrapListPanel;
+import gotcha.ui.review.UserReviewScreen;
 
 import javax.swing.*;
 import java.awt.*;

--- a/src/main/java/gotcha/ui/mypage/PreviousClassesPanel.java
+++ b/src/main/java/gotcha/ui/mypage/PreviousClassesPanel.java
@@ -25,16 +25,24 @@ public class PreviousClassesPanel extends JPanel {
 	}
 	
 	private void refreshTable() {
-		DefaultTableModel model = new DefaultTableModel();
-		model.setColumnIdentifiers(new String[] {"소모임 이름", "설명"});
-		List<Vector<String>> previousClasses = previousClassesService.getPreviousClasses(userId);
-		
-		if (previousClasses != null) {
-			for (Vector<String> row : previousClasses) {
-				model.addRow(new String[] {row.get(1), row.get(2)});
-			}
-		}
-		previousClassesTable.setModel(model);
-		previousClassesTable.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
+	    DefaultTableModel model = new DefaultTableModel();
+	    model.setColumnIdentifiers(new String[] {"소모임 이름", "설명"});
+
+	    List<Vector<String>> previousClasses = previousClassesService.getPreviousClasses(userId);
+
+	    if (previousClasses != null) {
+	        for (Vector<String> row : previousClasses) {
+	            if (row.size() >= 2) {
+	                model.addRow(new String[] {row.get(0), row.get(1)}); // ✅ 수정
+	            } else {
+	                System.out.println("🚨 잘못된 row: " + row);
+	            }
+	        }
+	    }
+
+	    previousClassesTable.setModel(model);
+	    previousClassesTable.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
 	}
+
+
 }

--- a/src/main/java/gotcha/ui/review/HostReviewScreen.java
+++ b/src/main/java/gotcha/ui/review/HostReviewScreen.java
@@ -1,0 +1,41 @@
+package gotcha.ui.review;
+
+import gotcha.dao.ReviewDAO;
+import gotcha.dao.ReviewDAO.HostReview;
+
+import javax.swing.*;
+import javax.swing.table.DefaultTableModel;
+import java.awt.*;
+import java.util.List;
+
+public class HostReviewScreen extends JDialog {
+	 public HostReviewScreen(JFrame parent, int classId) {
+	        super(parent, "주최자 리뷰 조회", true);
+	        setSize(600, 400);
+	        setLocationRelativeTo(parent);
+
+	        ReviewDAO dao = new ReviewDAO();
+	        List<ReviewDAO.HostReview> reviews = dao.getHostReviewsByClassId(classId);
+
+	        String[] cols = {"닉네임", "평점", "리뷰 내용"};
+	        DefaultTableModel model = new DefaultTableModel(cols, 0) {
+	            @Override
+	            public boolean isCellEditable(int r, int c) { return false; }
+	        };
+
+	        for (ReviewDAO.HostReview r : reviews) {
+	            model.addRow(new Object[]{r.getReviewerName(), String.format("%.1f", r.getRating()), r.getContent()});
+	        }
+
+	        JTable table = new JTable(model);
+	        JScrollPane scroll = new JScrollPane(table);
+	        add(scroll, BorderLayout.CENTER);
+
+	        JButton closeBtn = new JButton("닫기");
+	        closeBtn.addActionListener(e -> dispose());
+	        JPanel btnPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+	        btnPanel.add(closeBtn);
+	        add(btnPanel, BorderLayout.SOUTH);
+	    }
+}
+

--- a/src/main/java/gotcha/ui/review/ParticipantReviewWriteScreen.java
+++ b/src/main/java/gotcha/ui/review/ParticipantReviewWriteScreen.java
@@ -1,0 +1,111 @@
+package gotcha.ui.review;
+
+import gotcha.Main;
+import gotcha.common.FontLoader;
+import gotcha.dao.ParticipantReviewDAO;
+import gotcha.dto.ParticipantReview;
+import gotcha.ui.home.OtherGroupDetailScreen;
+
+import javax.swing.*;
+import java.awt.*;
+
+public class ParticipantReviewWriteScreen extends JPanel {
+    public ParticipantReviewWriteScreen(int classId, int writerId, int targetId) {
+        setLayout(new BorderLayout());
+
+        // 상단 제목
+        JLabel title = new JLabel("리뷰 작성 / 수정 / 삭제", SwingConstants.CENTER);
+        title.setFont(FontLoader.loadCustomFont(18f).deriveFont(Font.BOLD));
+        add(title, BorderLayout.NORTH);
+
+        // DAO 호출
+        ParticipantReviewDAO dao = new ParticipantReviewDAO();
+        ParticipantReview review = dao.getReview(classId, writerId, targetId);
+
+        // 입력 폼 (가운데)
+        JPanel formPanel = new JPanel(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
+        Font font = FontLoader.loadCustomFont(14f);
+
+        // 평점
+        gbc.insets = new Insets(5, 10, 5, 10);
+        gbc.gridx = 0; gbc.gridy = 0; gbc.anchor = GridBagConstraints.EAST;
+        formPanel.add(new JLabel("평점 (0.0 ~ 5.0):"), gbc);
+
+        JTextField ratingField = new JTextField();
+        ratingField.setFont(font);
+        if (review != null) {
+            ratingField.setText(String.valueOf(review.getRating()));
+        }
+        gbc.gridx = 1; gbc.fill = GridBagConstraints.HORIZONTAL; gbc.weightx = 1.0;
+        formPanel.add(ratingField, gbc);
+
+        // 리뷰 내용
+        gbc.gridx = 0; gbc.gridy = 1;
+        gbc.fill = GridBagConstraints.NONE; gbc.weightx = 0;
+        gbc.anchor = GridBagConstraints.NORTHEAST;
+        formPanel.add(new JLabel("리뷰 내용:"), gbc);
+
+        JTextArea contentArea = new JTextArea(5, 30);
+        contentArea.setFont(font);
+        contentArea.setLineWrap(true);
+        contentArea.setWrapStyleWord(true);
+        if (review != null) {
+            contentArea.setText(review.getContent());
+        }
+        JScrollPane scroll = new JScrollPane(contentArea);
+        gbc.gridx = 1; gbc.fill = GridBagConstraints.BOTH; gbc.weightx = 1.0; gbc.weighty = 1.0;
+        formPanel.add(scroll, gbc);
+
+        add(formPanel, BorderLayout.CENTER);
+
+        // 버튼 패널 (오른쪽 하단)
+        JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 10, 10));
+        JButton saveBtn = new JButton(review == null ? "작성" : "수정");
+        JButton backBtn = new JButton("뒤로가기");
+        buttonPanel.add(saveBtn);
+        
+        if (review != null) {
+            JButton deleteBtn = new JButton("삭제");
+            deleteBtn.addActionListener(e -> {
+                dao.deleteReview(review.getReviewId());
+                JOptionPane.showMessageDialog(this, "리뷰가 삭제되었습니다!");
+                Main.setScreen(new OtherGroupDetailScreen(classId, writerId));
+            });
+            buttonPanel.add(deleteBtn);
+        }
+
+        saveBtn.addActionListener(e -> {
+            try {
+                float rating = Float.parseFloat(ratingField.getText());
+                String content = contentArea.getText().trim();
+
+                if (content.isEmpty()) {
+                    JOptionPane.showMessageDialog(this, "리뷰 내용을 입력해주세요.");
+                    return;
+                }
+
+                if (rating < 0.0 || rating > 5.0) {
+                    JOptionPane.showMessageDialog(this, "평점은 0.0 ~ 5.0 사이여야 합니다.");
+                    return;
+                }
+
+                if (review == null) {
+                    dao.writeReview(classId, writerId, targetId, rating, content);
+                    JOptionPane.showMessageDialog(this, "리뷰가 등록되었습니다!");
+                } else {
+                    dao.updateReview(review.getReviewId(), rating, content);
+                    JOptionPane.showMessageDialog(this, "리뷰가 수정되었습니다!");
+                }
+                Main.setScreen(new OtherGroupDetailScreen(classId, writerId));
+            } catch (NumberFormatException ex) {
+                JOptionPane.showMessageDialog(this, "평점은 숫자 형식으로 입력해주세요.");
+            }
+        });
+
+        buttonPanel.add(backBtn);
+        backBtn.addActionListener(e -> Main.setScreen(new OtherGroupDetailScreen(classId, writerId)));
+
+        add(buttonPanel, BorderLayout.SOUTH);
+    }
+}

--- a/src/main/java/gotcha/ui/review/UserReviewScreen.java
+++ b/src/main/java/gotcha/ui/review/UserReviewScreen.java
@@ -1,4 +1,4 @@
-package gotcha.ui;
+package gotcha.ui.review;
 
 import gotcha.dao.UserReviewDAO;
 import gotcha.service.UserReviewService;

--- a/src/main/java/gotcha/ui/review/ViewParticipantReviewScreen.java
+++ b/src/main/java/gotcha/ui/review/ViewParticipantReviewScreen.java
@@ -1,0 +1,78 @@
+// ✅ ViewParticipantReviewScreen.java (Updated)
+package gotcha.ui.review;
+
+import gotcha.Main;
+import gotcha.common.FontLoader;
+import gotcha.dao.ParticipantDAO;
+import gotcha.dto.Participant;
+import gotcha.ui.home.OtherGroupDetailScreen;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.List;
+
+public class ViewParticipantReviewScreen extends JPanel {
+    private int classId;
+    private int writerId;
+
+    public ViewParticipantReviewScreen(int classId, int writerId) {
+        this.classId = classId;
+        this.writerId = writerId;
+
+        setLayout(new BorderLayout());
+
+        // 제목
+        JLabel title = new JLabel("리뷰할 참여자 선택", SwingConstants.CENTER);
+        title.setFont(FontLoader.loadCustomFont(16f).deriveFont(Font.BOLD));
+        title.setBorder(BorderFactory.createEmptyBorder(15, 0, 15, 0));
+        add(title, BorderLayout.NORTH);
+
+        // 참여자 리스트
+        ParticipantDAO dao = new ParticipantDAO();
+        List<Participant> participants = dao.getParticipants(classId, writerId);
+
+        DefaultListModel<Participant> model = new DefaultListModel<>();
+        for (Participant p : participants) model.addElement(p);
+
+        JList<Participant> list = new JList<>(model);
+        list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        list.setFont(FontLoader.loadCustomFont(14f));
+        list.setCellRenderer((list1, value, index, isSelected, cellHasFocus) -> {
+            JLabel label = new JLabel(value.getNickname());
+            label.setFont(FontLoader.loadCustomFont(14f));
+            label.setBorder(BorderFactory.createEmptyBorder(8, 12, 8, 12));
+            if (isSelected) {
+                label.setBackground(new Color(240, 240, 255));
+                label.setOpaque(true);
+            } else {
+                label.setOpaque(true);
+                label.setBackground(Color.WHITE);
+            }
+            return label;
+        });
+
+        JScrollPane scrollPane = new JScrollPane(list);
+        scrollPane.setBorder(BorderFactory.createEmptyBorder(5, 10, 5, 10));
+        add(scrollPane, BorderLayout.CENTER);
+
+        // 버튼 패널
+        JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 10, 10));
+
+        JButton reviewBtn = new JButton("리뷰 쓰러 가기");
+        reviewBtn.addActionListener(e -> {
+            Participant selected = list.getSelectedValue();
+            if (selected != null) {
+                Main.setScreen(new ParticipantReviewWriteScreen(classId, writerId, selected.getUserId()));
+            } else {
+                JOptionPane.showMessageDialog(this, "참여자를 선택해주세요.");
+            }
+        });
+
+        JButton backBtn = new JButton("뒤로가기");
+        backBtn.addActionListener(e -> Main.setScreen(new OtherGroupDetailScreen(classId, writerId)));
+
+        buttonPanel.add(reviewBtn);
+        buttonPanel.add(backBtn);
+        add(buttonPanel, BorderLayout.SOUTH);
+    }
+}


### PR DESCRIPTION
-  previousclasses 인덱스 관련 오류 수정 완료 
- 참여중 모임/타인 주최 모임 상세 볼 때 가입 버튼(soft-delete처리), 스크랩 버튼(취소까지) 로직 추가 
-  홈화면 상세 연결 때문에 메인 모델 수정
-  소모임 상세화면에 주최자 리뷰 조회 버튼 추가 
-  가입 여부에 따라 참여자 대상 리뷰 남기는 버튼 보이게 
-  참여자 리스트 조회 이후 선택
-  리뷰 작성 화면 - 선택 시 뒤로가기도 추가 
-  리뷰 작성 수정 및 삭제

https://www.notion.so/yoonot/209fc8937f6580b2b209eb83f62c7a16 스크린샷 일부


close #48, #51 